### PR TITLE
unlinked weather.js from index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
   <script src="https://cdn.jsdelivr.net/npm/dayjs@1.11.3/dayjs.min.js"
   integrity="sha256-iu/zLUB+QgISXBLCW/mcDi/rnf4m4uEDO0wauy76x7U=" crossorigin="anonymous"></script>
   <script src="./assets/js/form.js"></script>
-  <script src="./assets/js/weather.js"></script>
+  <!-- <script src="./assets/js/weather.js"></script> -->
 
 </body>
 


### PR DESCRIPTION
Karol's error was coming from the weather.js because it is linked to her index.html. All the data being collected should only be sent to form.js. The render page should handle all js scripts as it currently does. 